### PR TITLE
Update minimax portion

### DIFF
--- a/RemezProblem.qmd
+++ b/RemezProblem.qmd
@@ -25,13 +25,13 @@ where the maximum is taken over all points in the interval.
 
 Most of the time, statisticians are interested in least-squares $L_2$ or $L_1$ approximations. But such an $L_{\infty}$ solution can be important, e.g., if one has to guarantee the a polynomial approximation is accurate within a specific $\epsilon$ distance from the true function value on a whole interval.
 
-The **Remez algorithm** (Remez 1934) is a complicative iterative procedure that has problems with floating-point precision. So there are not so many correct implementations in open-source software. The result is called the *minimax approximation*. See the Wikipedia article
+The **Remez algorithm** (Remez 1934) is a complicated iterative procedure that has problems with floating-point precision. So there are not so many correct implementations in open-source software. The result is called the *minimax approximation*. See the Wikipedia article
 [Remez algorithm](https://en.wikipedia.org/wiki/Remez_algorithm)
 for a short overview of the algorithm and its numerical problems with stability, and some more references.
 
 We will show how a discretized form of the Remez problem can be quite accurately solved in R as a convex problem resp. as a *minimax* problem with constrained optimization solvers. The difference to the true solution is relatively small.
 
-We will also show how existing Remez implementations in MATLAB or Julia can be called. Since short time there is also a first implementation in R that can be downloaded from CRAN. Our consistent example for the rest of the note will be the Runge function which is well-known for its problem with oscillations at the edges of the interval $[-1, 1]$
+We will also show how existing Remez implementations in MATLAB or Julia can be called. Recently, there is also a first implementation in R that can be downloaded from CRAN. Our consistent example for the rest of the note will be the Runge function which is well-known for its problem with oscillations at the edges of the interval $[-1, 1]$
 
 $$
 \mathrm{Runge}(x) = \frac{1}{1 + (5x)^2}
@@ -55,10 +55,10 @@ library(CVXR, warn.conflicts = FALSE)
 fnRunge <- function(x) 1.0 / (1 + 25*x^2)
 
 n <- 101; m = 11            # polynomial of degree 10
-x <- seq(-1, 1, length=n)   # 101 grid points
+x <- seq(-1, 1, length = n)   # 101 grid points
 y <- fnRunge(x)             # apply Runge's function
 
-A <- outer(x, (m-1):0, '^') # Vandermonde matrix
+A <- outer(x, (m - 1):0, '^') # Vandermonde matrix
 ```
 
 Now we can formulate the minimax request as minimizing the expression `max(abs(y - A %*% p))` in the syntax required by the 'CVXR' package.
@@ -79,11 +79,11 @@ Of course, the result will be more accurate when more grid points are used. For 
 Here is a plot showing the Runge function and its polynomial minimax approximation of degree 10. 
 
 ```{r}
-plot(x, y, type ='l', col = "blue",     # plot the Runge function
+plot(x, y, type = 'l', col = "blue",     # plot the Runge function
      ylim = c(-0.1, 1.1), main = "Runge function and approximation")
 grid()
 yp <- polyval(c(p), x)                  # calculate the fitted values
-lines(x, yp, col ="red")                #   and plot them in red
+lines(x, yp, col = "red")                #   and plot them in red
 ```
 
 As a complex-analytic function, Runge has a pole at $0 + 0.2\,i$ that prevents polynomials to approximate it as well as one would expect.
@@ -196,49 +196,41 @@ Actually, 'Remez.jl' applies higher-precision numbers ("big numbers") to minimiz
 
 ### R package 'minimaxApprox'
 
-There is a new package on CRAN that attempts to implement the Remez algorithm in pure R. It is usable, but there appear to be bugs. When we ask for a polynomial approximation of degree 10, we get an error message.
+There is a new package on CRAN that attempts to implement the Remez algorithm in R and C. When asked for a degree 10 polynomial approximation it does not converge due the singularity of the linear equation matrix, but its default is to automatically check the next degree higher for convergence **and** for the highest-degree polynomial to be close to 0 (handled by the `tailtol` option). In this case, it works. The function returns the following results and message:
 
 ```{r}
 library(minimaxApprox)
 from <- -1.0; to <- 1.0
 fnRunge <- function(x) 1/(1 + (5 * x)^2)
-```
-
-```r
 sol <- minimaxApprox(fn = fnRunge, from, to, degree = 10)
-## Error in solve.default(polyMat(x, y, relErr), y) :
-##  system is computationally singular:
-##  reciprocal condition number = 2.00539e-19
+sol
 ```
 
-Instead we will try degree 11 hoping for a result that can be interpreted in polynomial degree 10, too.
+The function found the degree 10 polynomial by checking the degree 11.
+
+We can also calculate the minimax error manually in two ways:
+
+  1. Using `minimaxApprox::minimaxErr`
+  2. Using `pracma`'s `polyval` function, for which we have to reverse the coefficients):
 
 ```{r}
-sol <- minimaxApprox(fn = fnRunge, from, to, degree = 11)
-sol$a
-```
-
-and with an 'observed' resp. 'expected' error of 0.06592293.
-
-The highest coefficient is almost 0, so forgetting it will leave us with a vector of length 11, or as a coefficient vector of a 10th degree polynomial. We calculate the minimax error manually (for applying 'pracma's `polyval` function we have to reverse the coefficients):
-
-```{r}
+max(abs(minimaxErr(x, sol)))
 p <- rev(sol$a[1:11])
 max(abs(pracma::polyval(p, x) - y))
 ```
 
-We also see that the uneven coefficients are very small. The reason is that the Runge function is 'even', i.e., `fnRunge(-x) = fnRunge(x)`. If we set all these coefficients to 0, the result is not as good as before.
+These match with value returned by Chebfun. However, ee also see that the odd coefficients are very small. The reason is that the Runge function is 'even', i.e., `fnRunge(-x) = fnRunge(x)`. Using the package's `ztol` option, we can request that values whose contribution to the sum are below a certain tolerance be set to 0. Here we can set `ztol` to 1e-9. 
 
 ```{r}
-p <- rev(zapsmall(sol$a[1:11]))
-max(abs(pracma::polyval(p, x) - y))
+sol2 <- minimaxApprox(fn = fnRunge, from, to, degree = 10, opts = list(ztol = 1e-9))
+sol2
 ```
 
-This indicates that the coefficients that `minimaxApprox` produces are not really accurate. We hope for further approvements in this package. 
+This indicates that the very small coefficients that `minimaxApprox` produced are a function of machine precision issues and can be ignored.
 
 ## An example
 
-The Remez algorithm is often utilized in Signal processing for the problem of optimal signal design. Here we will apply it to function approximation, verifying an approximation in the "Handbook of Mathematical Functions" by Abramovichand Stegun.
+The Remez algorithm is often utilized in Signal processing for the problem of optimal signal design. Here we will apply it to function approximation, verifying an approximation in the "Handbook of Mathematical Functions" by Abramovich and Stegun.
 
 For the Gamma function on the interval $[1, 2]$ the following polynomial approximation is given (on p. 257) as
 

--- a/RemezProblem.qmd
+++ b/RemezProblem.qmd
@@ -211,7 +211,7 @@ The function found the degree 10 polynomial by checking the degree 11.
 We can also calculate the minimax error manually in two ways:
 
   1. Using `minimaxApprox::minimaxErr`
-  2. Using `pracma`'s `polyval` function, for which we have to reverse the coefficients):
+  2. Using `pracma`'s `polyval` function, for which we have to reverse the coefficients:
 
 ```{r}
 max(abs(minimaxErr(x, sol)))
@@ -219,7 +219,7 @@ p <- rev(sol$a[1:11])
 max(abs(pracma::polyval(p, x) - y))
 ```
 
-These match with value returned by Chebfun. However, ee also see that the odd coefficients are very small. The reason is that the Runge function is 'even', i.e., `fnRunge(-x) = fnRunge(x)`. Using the package's `ztol` option, we can request that values whose contribution to the sum are below a certain tolerance be set to 0. Here we can set `ztol` to 1e-9. 
+These match with value returned by Chebfun. However, we also see that the odd coefficients are very small. The reason is that the Runge function is 'even', i.e., `fnRunge(-x) = fnRunge(x)`. Using the package's `ztol` option, we can request that values whose contribution to the sum are below a certain tolerance be set to 0. Here we can set `ztol` to 1e-9. 
 
 ```{r}
 sol2 <- minimaxApprox(fn = fnRunge, from, to, degree = 10, opts = list(ztol = 1e-9))


### PR DESCRIPTION
Using the "updated" package it returns the same error and coefficients as Chebfun. Also shows use of the ztol parameter and minimaxErr function. Technically this is version 0.2.1, but it's identical to 0.2.0. The only change is removing one test from CRAN test-bed.

Feel free to adjust, rewrite, or refuse/cancel as you see fit :)